### PR TITLE
Fix: Resolve issue #3 - Buff interval logic corrected

### DIFF
--- a/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
@@ -74,12 +74,10 @@ public final class ConfigManager {
 
 	/**
 	 * Gets the configured interval (in ticks) between applying island buffs.
-	 * Note: The config value is in seconds, but this method returns ticks.
 	 * @return The buff update interval in ticks.
 	 */
 	public static int getBuffUpdateInterval() {
-		// Convert seconds from config to ticks
-		return config.buffUpdateInterval * 20;
+		return config.buffUpdateInterval;
 	}
 
 	/**
@@ -97,7 +95,7 @@ public final class ConfigManager {
 	private static class Config {
 		/** Interval in ticks for checking if players are outside their island boundaries. Default: 10 ticks. */
 		int boundaryCheckInterval = 10;
-		/** Interval in seconds for applying island-specific buffs. Default: 60 seconds. */
+		/** Interval in ticks for applying island-specific buffs. Default: 60 ticks (3 seconds). */
 		int buffUpdateInterval = 60;
 		/** Interval in ticks for attempting to trigger a random disaster. Default: 6000 ticks (5 minutes). */
 		int disasterIntervalTicks = 20 * 60 * 5;


### PR DESCRIPTION
- Updated `buffUpdateInterval` in `ConfigManager` to be specified directly in ticks.
- Adjusted the default value to 60 ticks (3 seconds).
- Removed the conversion logic (multiplication by 20) in `getBuffUpdateInterval`.
- Updated comments and documentation to reflect the tick-based configuration.

This commit fixes [issue #3](https://github.com/no-felix/stormbound-isles/issues/3), ensuring buffs are applied at the correct interval.