### PR TITLE
fix: refactor config handling and scoreboard team logic

### DIFF
--- a/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
@@ -1,6 +1,7 @@
 package de.nofelix.stormboundisles.config;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder; // Import GsonBuilder
 import com.google.gson.JsonSyntaxException;
 import de.nofelix.stormboundisles.StormboundIslesMod;
 import net.fabricmc.loader.api.FabricLoader;
@@ -20,7 +21,7 @@ public final class ConfigManager {
 	/** The filename for the configuration file. */
 	private static final String CONFIG_FILENAME = "stormbound-isles-config.json";
 	/** Gson instance for JSON handling. */
-	private static final Gson GSON = new Gson();
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 	/** The loaded configuration instance. */
 	private static Config config;
 
@@ -41,63 +42,123 @@ public final class ConfigManager {
 				.toFile();
 
 		if (!configFile.exists()) {
-			config = new Config();
+			config = new Config(); // Create default config
 			try (FileWriter writer = new FileWriter(configFile)) {
 				GSON.toJson(config, writer);
+				log.info("Created default config file: {}", CONFIG_FILENAME);
 			} catch (IOException e) {
 				log.error("Failed to write default config to {}", CONFIG_FILENAME, e);
 			}
 		} else {
 			try (FileReader reader = new FileReader(configFile)) {
 				config = GSON.fromJson(reader, Config.class);
+				// Handle cases where the file exists but is empty or invalid JSON root
+				if (config == null) {
+					log.warn("Config file {} was empty or invalid. Creating default config.", CONFIG_FILENAME);
+					config = new Config();
+					// Optionally overwrite the invalid file with defaults
+					try (FileWriter writer = new FileWriter(configFile)) {
+						GSON.toJson(config, writer);
+						log.info("Overwrote invalid config file {} with defaults.", CONFIG_FILENAME);
+					} catch (IOException e) {
+						log.error("Failed to overwrite invalid config file {} with defaults.", CONFIG_FILENAME, e);
+					}
+				} else {
+					// Ensure nested objects are not null if the file was partially valid
+					if (config.game == null) config.game = new Config.Game();
+					if (config.player == null) config.player = new Config.Player();
+					if (config.buff == null) config.buff = new Config.Buff();
+					if (config.disaster == null) config.disaster = new Config.Disaster();
+				}
 			} catch (IOException | JsonSyntaxException e) {
-				log.error("Failed to load {} (using defaults)", CONFIG_FILENAME, e);
-				config = new Config();
+				log.error("Failed to load {} (using defaults): {}", CONFIG_FILENAME, e.getMessage());
+				config = new Config(); // Fallback to defaults on error
 			}
 		}
 
-		log.info(
-				"Config loaded: boundaryInterval={}, buffInterval={}, disasterIntervalTicks={}",
-				config.boundaryCheckInterval,
-				config.buffUpdateInterval,
-				config.disasterIntervalTicks
+		// Log loaded/default values (consider logging nested structure)
+		log.info("Config loaded. Game(BuildTicks={}, PvpTicks={}, CountdownTicks={}), Player(BoundaryInterval={}, DeathPenalty={}, WarningCooldownMs={}), Buff(UpdateInterval={}, DurationTicks={}), Disaster(IntervalTicks={}, EffectDurationTicks={}, CooldownTicks={}, MeteorDamage={}, BlizzardFreezeTicks={})",
+				config.game.buildPhaseTicks, config.game.pvpPhaseTicks, config.game.countdownDurationTicks,
+				config.player.boundaryCheckInterval, config.player.deathPenalty, config.player.boundaryWarningCooldownMs,
+				config.buff.buffUpdateInterval, config.buff.buffDurationTicks,
+				config.disaster.disasterIntervalTicks, config.disaster.disasterEffectDurationTicks, config.disaster.disasterCooldownTicks, config.disaster.meteorDamage, config.disaster.blizzardFreezeTicks
 		);
 	}
 
-	/**
-	 * Gets the configured interval (in ticks) between player boundary checks.
-	 * @return The boundary check interval in ticks.
-	 */
-	public static int getBoundaryCheckInterval() {
-		return config.boundaryCheckInterval;
-	}
+	// --- Getters for Config Values ---
+
+	// Game Settings
+	public static int getGameBuildPhaseTicks() { return config.game.buildPhaseTicks; }
+	public static int getGamePvpPhaseTicks() { return config.game.pvpPhaseTicks; }
+	public static int getGameCountdownDurationTicks() { return config.game.countdownDurationTicks; }
+
+	// Player Settings
+	public static int getPlayerBoundaryCheckInterval() { return config.player.boundaryCheckInterval; }
+	public static int getPlayerDeathPenalty() { return config.player.deathPenalty; }
+	public static long getPlayerBoundaryWarningCooldownMs() { return config.player.boundaryWarningCooldownMs; }
+
+	// Buff Settings
+	public static int getBuffUpdateInterval() { return config.buff.buffUpdateInterval; }
+	public static int getBuffDurationTicks() { return config.buff.buffDurationTicks; }
+
+	// Disaster Settings
+	public static int getDisasterIntervalTicks() { return config.disaster.disasterIntervalTicks; }
+	public static int getDisasterEffectDurationTicks() { return config.disaster.disasterEffectDurationTicks; }
+	public static int getDisasterCooldownTicks() { return config.disaster.disasterCooldownTicks; }
+	public static float getDisasterMeteorDamage() { return config.disaster.meteorDamage; }
+	public static int getDisasterBlizzardFreezeTicks() { return config.disaster.blizzardFreezeTicks; }
+
 
 	/**
-	 * Gets the configured interval (in ticks) between applying island buffs.
-	 * @return The buff update interval in ticks.
-	 */
-	public static int getBuffUpdateInterval() {
-		return config.buffUpdateInterval;
-	}
-
-	/**
-	 * Gets the configured interval (in ticks) between potential disaster events.
-	 * @return The disaster interval in ticks.
-	 */
-	public static int getDisasterIntervalTicks() {
-		return config.disasterIntervalTicks;
-	}
-
-	/**
-	 * Internal class representing the structure of the configuration file.
-	 * Contains default values for all settings.
+	 * Root class representing the structure of the configuration file.
+	 * Contains nested classes for different setting categories.
 	 */
 	private static class Config {
-		/** Interval in ticks for checking if players are outside their island boundaries. Default: 10 ticks. */
-		int boundaryCheckInterval = 10;
-		/** Interval in ticks for applying island-specific buffs. Default: 60 ticks (3 seconds). */
-		int buffUpdateInterval = 60;
-		/** Interval in ticks for attempting to trigger a random disaster. Default: 6000 ticks (5 minutes). */
-		int disasterIntervalTicks = 20 * 60 * 5;
+		Game game = new Game();
+		Player player = new Player();
+		Buff buff = new Buff();
+		Disaster disaster = new Disaster();
+
+		/** Game-related settings like phase durations and countdowns. */
+		static class Game {
+			/** Duration of the build phase in ticks. Default: 12096000 ticks (1 week). */
+			int buildPhaseTicks = 20 * 60 * 60 * 24 * 7; // 12096000
+			/** Duration of the PvP phase in ticks. Default: 12096000 ticks (1 week). */
+			int pvpPhaseTicks = 20 * 60 * 60 * 24 * 7;   // 12096000
+			/** Duration in ticks for the pre-game countdown. Default: 200 ticks (10 seconds). */
+			int countdownDurationTicks = 20 * 10; // 200
+		}
+
+		/** Player-related settings like boundary checks and penalties. */
+		static class Player {
+			/** Interval in ticks for checking if players are outside their island boundaries. Default: 10 ticks. */
+			int boundaryCheckInterval = 10;
+			/** Points deducted from a team when a member dies. Default: 10 points. */
+			int deathPenalty = 10;
+			/** Cooldown in milliseconds before a player receives another boundary warning message. Default: 3000ms (3 seconds). */
+			long boundaryWarningCooldownMs = 3000L;
+		}
+
+		/** Settings related to island buffs. */
+		static class Buff {
+			/** Interval in ticks for applying island-specific buffs. Default: 60 ticks (3 seconds). */
+			int buffUpdateInterval = 60;
+			/** Duration in ticks for island buffs. Default: 80 ticks (4 seconds). */
+			int buffDurationTicks = 80;
+		}
+
+		/** Settings related to disasters. */
+		static class Disaster {
+			/** Interval in ticks for attempting to trigger a random disaster. Default: 6000 ticks (5 minutes). */
+			int disasterIntervalTicks = 20 * 60 * 5; // 6000
+			/** Duration in ticks for disaster status effects (Blindness, Poison, Levitation). Default: 100 ticks (5 seconds). */
+			int disasterEffectDurationTicks = 100;
+			/** Cooldown in ticks before a disaster can re-trigger on the same island. Default: 100 ticks (5 seconds). */
+			int disasterCooldownTicks = 100;
+			/** Damage dealt by a single meteor hit during the METEOR disaster. Default: 8.0F (4 hearts). */
+			float meteorDamage = 8.0F;
+			/** Additional freeze ticks applied by the BLIZZARD disaster. Default: 200 ticks (10 seconds). */
+			int blizzardFreezeTicks = 200;
+		}
 	}
 }

--- a/src/main/java/de/nofelix/stormboundisles/data/DataManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/data/DataManager.java
@@ -2,281 +2,431 @@ package de.nofelix.stormboundisles.data;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import de.nofelix.stormboundisles.StormboundIslesMod;
 import de.nofelix.stormboundisles.game.GameManager;
 import de.nofelix.stormboundisles.game.GamePhase;
 import net.fabricmc.loader.api.FabricLoader;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 /**
  * Manages loading and saving persistent game data, including team information,
  * island definitions, and the current game state (phase and progress).
  * Data is stored in JSON files within the world save directory (`world/stormboundisles`).
+ * This class uses static methods and fields for global access.
  */
-public class DataManager {
-	/** Gson instance for JSON serialization/deserialization with pretty printing. */
-	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-	/** Type token for deserializing the map of teams (String teamName -> Team object). */
-	private static final Type TEAM_MAP_TYPE = new TypeToken<Map<String, Team>>() {
-	}.getType();
-	/** Type token for deserializing the map of islands (String islandId -> Island object). */
-	private static final Type ISLAND_MAP_TYPE = new TypeToken<Map<String, Island>>() {
-	}.getType();
-	/** In-memory map storing team data, keyed by team name. Loaded from `teams.json`. */
-	private static Map<String, Team> teams = new HashMap<>();
-	/** In-memory map storing island data, keyed by island ID. Loaded from `islands.json`. */
-	private static Map<String, Island> islands = new HashMap<>();
+public final class DataManager {
+    // Constants
+    private static final String DATA_DIR_NAME = "stormboundisles";
+    private static final String ISLANDS_FILENAME = "islands.json";
+    private static final String TEAMS_FILENAME = "teams.json";
+    private static final String GAME_STATE_FILENAME = "game_state.json";
 
-	/**
-	 * Returns an unmodifiable view of the teams map.
-	 * 
-	 * @return An unmodifiable map of teams
-	 */
-	public static Map<String, Team> getTeams() {
-		return Map.copyOf(teams);
-	}
+    // JSON serialization configuration
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .create();
 
-	/**
-	 * Returns an unmodifiable view of the islands map.
-	 * 
-	 * @return An unmodifiable map of islands
-	 */
-	public static Map<String, Island> getIslands() {
-		return Map.copyOf(islands);
-	}
+    // Type tokens for JSON deserialization
+    private static final Type TEAM_MAP_TYPE = new TypeToken<Map<String, Team>>() {}.getType();
+    private static final Type ISLAND_MAP_TYPE = new TypeToken<Map<String, Island>>() {}.getType();
 
-	/**
-	 * Gets a team by its name.
-	 * 
-	 * @param teamName The name of the team to retrieve
-	 * @return The team object, or null if no team exists with the given name
-	 */
-	public static Team getTeam(String teamName) {
-		return teams.get(teamName);
-	}
+    // Data storage - Using ConcurrentHashMap for thread safety with static fields
+    private static final Map<String, Team> teams = new ConcurrentHashMap<>();
+    private static final Map<String, Island> islands = new ConcurrentHashMap<>();
 
-	/**
-	 * Gets an island by its ID.
-	 * 
-	 * @param islandId The ID of the island to retrieve
-	 * @return The island object, or null if no island exists with the given ID
-	 */
-	public static Island getIsland(String islandId) {
-		return islands.get(islandId);
-	}
+    // Constructor - prevent instantiation of this utility class
+    private DataManager() {
+        throw new UnsupportedOperationException("DataManager is a utility class and cannot be instantiated.");
+    }
 
-	/**
-	 * Adds or updates a team in the teams collection.
-	 * 
-	 * @param team The team to add or update
-	 */
-	public static void putTeam(Team team) {
-		if (team == null || team.getName() == null) {
-			throw new IllegalArgumentException("Cannot add a null team or team with null name");
-		}
-		teams.put(team.getName(), team);
-	}
+    // --- Public API ---
 
-	/**
-	 * Adds or updates an island in the islands collection.
-	 * 
-	 * @param island The island to add or update
-	 */
-	public static void putIsland(Island island) {
-		if (island == null || island.getId() == null) {
-			throw new IllegalArgumentException("Cannot add a null island or island with null id");
-		}
-		islands.put(island.getId(), island);
-	}
+    /**
+     * Returns an unmodifiable view of the teams map.
+     * Modifications should be done via {@link #putTeam(Team)}.
+     *
+     * @return An unmodifiable map of team names to Team objects.
+     */
+    @NotNull
+    public static Map<String, Team> getTeams() {
+        return Collections.unmodifiableMap(teams);
+    }
 
-	/**
-	 * Clears all teams from the teams collection.
-	 */
-	public static void clearTeams() {
-		teams.clear();
-	}
+    /**
+     * Returns an unmodifiable view of the islands map.
+     * Modifications should be done via {@link #putIsland(Island)}.
+     *
+     * @return An unmodifiable map of island IDs to Island objects.
+     */
+    @NotNull
+    public static Map<String, Island> getIslands() {
+        return Collections.unmodifiableMap(islands);
+    }
 
-	/**
-	 * Clears all islands from the islands collection.
-	 */
-	public static void clearIslands() {
-		islands.clear();
-	}
+    /**
+     * Gets a team by its name.
+     *
+     * @param teamName The name of the team to retrieve. Must not be null.
+     * @return The {@link Team} object, or {@code null} if no team exists with the given name.
+     */
+    @Nullable
+    public static Team getTeam(@NotNull String teamName) {
+        return teams.get(teamName);
+    }
 
-	/**
-	 * Loads all data from the default directory.
-	 * Convenience method that uses the game directory from FabricLoader.
-	 */
-	public static void loadAll() {
-		Path runDir = FabricLoader.getInstance().getGameDir();
-		load(runDir);
-	}
+    /**
+     * Gets an island by its ID.
+     *
+     * @param islandId The ID of the island to retrieve. Must not be null.
+     * @return The {@link Island} object, or {@code null} if no island exists with the given ID.
+     */
+    @Nullable
+    public static Island getIsland(@NotNull String islandId) {
+        return islands.get(islandId);
+    }
 
-	/**
-	 * Loads all data from the appropriate JSON files.
-	 * If files don't exist or are invalid, initializes with empty collections.
-	 * 
-	 * @param runDir The directory where the game is running
-	 */
-	public static void load(@NotNull Path runDir) {
-		StormboundIslesMod.LOGGER.info("Loading data from {}", runDir);
-		try {
-			Path dataDir = ensureDataDirectory(runDir);
-			
-			// Load islands first since teams reference them
-			try {
-				Path islandsPath = dataDir.resolve("islands.json");
-				if (Files.exists(islandsPath)) {
-					String islandsJson = Files.readString(islandsPath, StandardCharsets.UTF_8);
-					islands = GSON.fromJson(islandsJson, ISLAND_MAP_TYPE);
-					StormboundIslesMod.LOGGER.info("Loaded {} islands", islands.size());
-				}
-			} catch (Exception e) {
-				StormboundIslesMod.LOGGER.error("Failed to load islands", e);
-				islands = new HashMap<>();
-			}
-			
-			// Load teams
-			try {
-				Path teamsPath = dataDir.resolve("teams.json");
-				if (Files.exists(teamsPath)) {
-					String teamsJson = Files.readString(teamsPath, StandardCharsets.UTF_8);
-					teams = GSON.fromJson(teamsJson, TEAM_MAP_TYPE);
-					StormboundIslesMod.LOGGER.info("Loaded {} teams", teams.size());
-				}
-			} catch (Exception e) {
-				StormboundIslesMod.LOGGER.error("Failed to load teams", e);
-				teams = new HashMap<>();
-			}
-			
-			// Load game state
-			try {
-				Path gameStatePath = dataDir.resolve("game_state.json");
-				if (Files.exists(gameStatePath)) {
-					String gameStateJson = Files.readString(gameStatePath, StandardCharsets.UTF_8);
-					GameState gameState = GSON.fromJson(gameStateJson, GameState.class);
-					if (gameState != null) {
-						GameManager.setPhaseWithoutReset(gameState.phase, gameState.phaseTicks);
-						StormboundIslesMod.LOGGER.info("Loaded game state: {} (ticks: {})", 
-								gameState.phase, gameState.phaseTicks);
-					}
-				}
-			} catch (Exception e) {
-				StormboundIslesMod.LOGGER.error("Failed to load game state", e);
-			}
-		} catch (Exception e) {
-			StormboundIslesMod.LOGGER.error("Error during data loading", e);
-		}
-	}
+    /**
+     * Adds or updates a team in the teams collection.
+     * This operation is thread-safe.
+     *
+     * @param team The team to add or update. Must not be null, and its name must not be null.
+     * @throws IllegalArgumentException If the team or team name is null.
+     */
+    public static void putTeam(@NotNull Team team) {
+        if (team.getName() == null) {
+            throw new IllegalArgumentException("Cannot add a team with a null name.");
+        }
+        teams.put(team.getName(), team);
+    }
 
-	/**
-	 * Creates and ensures the existence of the data directory for the mod.
-	 * 
-	 * @param runDir The base directory for the game
-	 * @return The path to the data directory
-	 * @throws IOException If directory creation fails
-	 */
-	private static Path ensureDataDirectory(Path runDir) throws IOException {
-		Path worldDir = runDir.resolve("world");
-		if (!Files.exists(worldDir)) {
-			worldDir = runDir;  // No world directory, use run directory directly
-		}
-		Path dataDir = worldDir.resolve("stormboundisles");
-		if (!Files.exists(dataDir)) {
-			Files.createDirectories(dataDir);
-			StormboundIslesMod.LOGGER.info("Created data directory: {}", dataDir);
-		}
-		return dataDir;
-	}
+    /**
+     * Adds or updates an island in the islands collection.
+     * This operation is thread-safe.
+     *
+     * @param island The island to add or update. Must not be null, and its ID must not be null.
+     * @throws IllegalArgumentException If the island or island ID is null.
+     */
+    public static void putIsland(@NotNull Island island) {
+        if (island.getId() == null) {
+            throw new IllegalArgumentException("Cannot add an island with a null ID.");
+        }
+        islands.put(island.getId(), island);
+    }
 
-	/**
-	 * Saves all data to the appropriate JSON files.
-	 */
-	public static void saveAll() {
-		Path runDir = FabricLoader.getInstance().getGameDir();
-		saveAll(runDir);
-	}
+    /**
+     * Clears all teams from the in-memory collection.
+     * Does not automatically persist this change; call {@link #saveAll()} or {@link #saveTeams()} if needed.
+     */
+    public static void clearTeams() {
+        teams.clear();
+        StormboundIslesMod.LOGGER.info("Cleared all in-memory teams.");
+    }
 
-	/**
-	 * Saves all data to the appropriate JSON files in the specified directory.
-	 * 
-	 * @param runDir The directory where the game is running
-	 */
-	public static void saveAll(Path runDir) {
-		try {
-			Path dataDir = ensureDataDirectory(runDir);
-			
-			// Save islands
-			try {
-				Path islandsPath = dataDir.resolve("islands.json");
-				String islandsJson = GSON.toJson(islands);
-				Files.writeString(islandsPath, islandsJson, StandardCharsets.UTF_8);
-				StormboundIslesMod.LOGGER.debug("Saved {} islands", islands.size());
-			} catch (Exception e) {
-				StormboundIslesMod.LOGGER.error("Failed to save islands", e);
-			}
-			
-			// Save teams
-			try {
-				Path teamsPath = dataDir.resolve("teams.json");
-				String teamsJson = GSON.toJson(teams);
-				Files.writeString(teamsPath, teamsJson, StandardCharsets.UTF_8);
-				StormboundIslesMod.LOGGER.debug("Saved {} teams", teams.size());
-			} catch (Exception e) {
-				StormboundIslesMod.LOGGER.error("Failed to save teams", e);
-			}
-			
-			// Save game state
-			saveGameState();
-		} catch (Exception e) {
-			StormboundIslesMod.LOGGER.error("Error during data saving", e);
-		}
-	}
+    /**
+     * Clears all islands from the in-memory collection.
+     * Does not automatically persist this change; call {@link #saveAll()} or {@link #saveIslands()} if needed.
+     */
+    public static void clearIslands() {
+        islands.clear();
+        StormboundIslesMod.LOGGER.info("Cleared all in-memory islands.");
+    }
 
-	/**
-	 * Saves only the game state to its JSON file.
-	 */
-	public static void saveGameState() {
-		Path runDir = FabricLoader.getInstance().getGameDir();
-		try {
-			Path dataDir = ensureDataDirectory(runDir);
-			try {
-				Path gameStatePath = dataDir.resolve("game_state.json");
-				GameState gameState = new GameState(
-						GameManager.phase, 
-						GameManager.getPhaseTicks()
-				);
-				String gameStateJson = GSON.toJson(gameState);
-				Files.writeString(gameStatePath, gameStateJson, StandardCharsets.UTF_8);
-				StormboundIslesMod.LOGGER.debug("Saved game state: {} (ticks: {})", 
-						gameState.phase, gameState.phaseTicks);
-			} catch (Exception e) {
-				StormboundIslesMod.LOGGER.error("Failed to save game state", e);
-			}
-		} catch (Exception e) {
-			StormboundIslesMod.LOGGER.error("Error during game state saving", e);
-		}
-	}
+    /**
+     * Loads all data (islands, teams, game state) from the default directory structure.
+     * Uses the game directory provided by FabricLoader.
+     * This should typically be called during mod initialization.
+     */
+    public static void loadAll() {
+        Path runDir = FabricLoader.getInstance().getGameDir();
+        load(runDir);
+    }
 
-	/**
-	 * Simple DTO for serializing/deserializing game state.
-	 */
-	private static class GameState {
-		public GamePhase phase;
-		public int phaseTicks;
+    /**
+     * Loads all data (islands, teams, game state) from the appropriate JSON files
+     * within the specified run directory structure.
+     * If files don't exist or are invalid, attempts to proceed with default/empty data.
+     *
+     * @param runDir The base directory where the game is running (e.g., server root). Must not be null.
+     */
+    public static void load(@NotNull Path runDir) {
+        StormboundIslesMod.LOGGER.info("Loading Stormbound Isles data from base directory: {}", runDir);
+        try {
+            Path dataDir = ensureDataDirectory(runDir);
 
-		public GameState(GamePhase phase, int phaseTicks) {
-			this.phase = phase;
-			this.phaseTicks = phaseTicks;
-		}
-	}
+            loadIslands(dataDir);
+            loadTeams(dataDir);
+            loadGameState(dataDir);
+
+            StormboundIslesMod.LOGGER.info("Finished loading Stormbound Isles data.");
+
+        } catch (IOException e) {
+            StormboundIslesMod.LOGGER.error("Fatal error accessing data directory '{}'. Data loading aborted.", DATA_DIR_NAME, e);
+        } catch (Exception e) {
+            StormboundIslesMod.LOGGER.error("Unexpected error during data loading process.", e);
+        }
+    }
+
+    /**
+     * Saves all data (islands, teams, game state) to the default directory structure.
+     * Uses the game directory provided by FabricLoader.
+     * This might be called on server stop or periodically.
+     */
+    public static void saveAll() {
+        Path runDir = FabricLoader.getInstance().getGameDir();
+        saveAll(runDir);
+    }
+
+    /**
+     * Saves all data (islands, teams, game state) to the appropriate JSON files
+     * within the specified run directory structure.
+     *
+     * @param runDir The base directory where the game is running (e.g., server root). Must not be null.
+     */
+    public static void saveAll(@NotNull Path runDir) {
+        StormboundIslesMod.LOGGER.info("Saving all Stormbound Isles data to base directory: {}", runDir);
+        try {
+            Path dataDir = ensureDataDirectory(runDir);
+
+            saveIslands(dataDir);
+            saveTeams(dataDir);
+            saveGameState(dataDir);
+
+            StormboundIslesMod.LOGGER.info("Finished saving Stormbound Isles data.");
+
+        } catch (IOException e) {
+            StormboundIslesMod.LOGGER.error("Fatal error accessing data directory '{}'. Data saving aborted.", DATA_DIR_NAME, e);
+        } catch (Exception e) {
+            StormboundIslesMod.LOGGER.error("Unexpected error during data saving process.", e);
+        }
+    }
+
+    /**
+     * Saves only the current game state (phase and ticks) to its JSON file
+     * in the default directory structure.
+     * Uses the game directory provided by FabricLoader.
+     */
+    public static void saveGameState() {
+        Path runDir = FabricLoader.getInstance().getGameDir();
+        try {
+            Path dataDir = ensureDataDirectory(runDir);
+            saveGameState(dataDir);
+        } catch (IOException e) {
+            StormboundIslesMod.LOGGER.error("Error accessing data directory for saving game state.", e);
+        } catch (Exception e) {
+            StormboundIslesMod.LOGGER.error("Unexpected error during game state saving.", e);
+        }
+    }
+
+    // --- Private Implementation Methods ---
+
+    /**
+     * Creates and ensures the existence of the data directory for the mod
+     * (e.g., `[runDir]/world/stormboundisles` or `[runDir]/stormboundisles`).
+     *
+     * @param runDir The base directory for the game (server root or client run dir). Must not be null.
+     * @return The {@link Path} to the data directory.
+     * @throws IOException If directory creation fails due to I/O errors.
+     */
+    @NotNull
+    private static Path ensureDataDirectory(@NotNull Path runDir) throws IOException {
+        Path worldDir = runDir.resolve("world");
+        Path baseDir = Files.isDirectory(worldDir) ? worldDir : runDir;
+
+        Path dataDir = baseDir.resolve(DATA_DIR_NAME);
+
+        Files.createDirectories(dataDir);
+
+        return dataDir;
+    }
+
+    /**
+     * Loads islands data from the specified JSON file.
+     * Clears current in-memory islands before loading. Handles file reading and JSON parsing errors.
+     *
+     * @param dataDir The data directory containing the islands file. Must not be null.
+     */
+    private static void loadIslands(@NotNull Path dataDir) {
+        Path islandsPath = dataDir.resolve(ISLANDS_FILENAME);
+        islands.clear();
+
+        if (Files.exists(islandsPath)) {
+            try (var reader = Files.newBufferedReader(islandsPath, StandardCharsets.UTF_8)) {
+                Map<String, Island> loadedIslands = GSON.fromJson(reader, ISLAND_MAP_TYPE);
+                if (loadedIslands != null) {
+                    islands.putAll(loadedIslands);
+                    StormboundIslesMod.LOGGER.info("Loaded {} islands from {}", islands.size(), islandsPath.getFileName());
+                } else {
+                    StormboundIslesMod.LOGGER.warn("Islands file {} was empty or contained null data.", islandsPath.getFileName());
+                }
+            } catch (IOException e) {
+                StormboundIslesMod.LOGGER.error("Could not read islands file: {}", islandsPath, e);
+            } catch (JsonParseException e) {
+                StormboundIslesMod.LOGGER.error("Invalid JSON format in islands file: {}", islandsPath, e);
+            } catch (Exception e) {
+                StormboundIslesMod.LOGGER.error("Unexpected error loading islands from file: {}", islandsPath, e);
+            }
+        } else {
+            StormboundIslesMod.LOGGER.info("Islands file {} not found. Starting with empty island data.", islandsPath.getFileName());
+        }
+    }
+
+    /**
+     * Loads teams data from the specified JSON file.
+     * Clears current in-memory teams before loading. Handles file reading and JSON parsing errors.
+     *
+     * @param dataDir The data directory containing the teams file. Must not be null.
+     */
+    private static void loadTeams(@NotNull Path dataDir) {
+        Path teamsPath = dataDir.resolve(TEAMS_FILENAME);
+        teams.clear();
+
+        if (Files.exists(teamsPath)) {
+            try (var reader = Files.newBufferedReader(teamsPath, StandardCharsets.UTF_8)) {
+                Map<String, Team> loadedTeams = GSON.fromJson(reader, TEAM_MAP_TYPE);
+                if (loadedTeams != null) {
+                    teams.putAll(loadedTeams);
+                    StormboundIslesMod.LOGGER.info("Loaded {} teams from {}", teams.size(), teamsPath.getFileName());
+                } else {
+                    StormboundIslesMod.LOGGER.warn("Teams file {} was empty or contained null data.", teamsPath.getFileName());
+                }
+            } catch (IOException e) {
+                StormboundIslesMod.LOGGER.error("Could not read teams file: {}", teamsPath, e);
+            } catch (JsonParseException e) {
+                StormboundIslesMod.LOGGER.error("Invalid JSON format in teams file: {}", teamsPath, e);
+            } catch (Exception e) {
+                StormboundIslesMod.LOGGER.error("Unexpected error loading teams from file: {}", teamsPath, e);
+            }
+        } else {
+            StormboundIslesMod.LOGGER.info("Teams file {} not found. Starting with empty team data.", teamsPath.getFileName());
+        }
+    }
+
+    /**
+     * Loads game state data from the specified JSON file and updates {@link GameManager}.
+     * Handles file reading and JSON parsing errors.
+     *
+     * @param dataDir The data directory containing the game state file. Must not be null.
+     */
+    private static void loadGameState(@NotNull Path dataDir) {
+        Path gameStatePath = dataDir.resolve(GAME_STATE_FILENAME);
+
+        if (Files.exists(gameStatePath)) {
+            try (var reader = Files.newBufferedReader(gameStatePath, StandardCharsets.UTF_8)) {
+                GameState gameState = GSON.fromJson(reader, GameState.class);
+                if (gameState != null && gameState.phase != null) {
+                    GameManager.setPhaseWithoutReset(gameState.phase, gameState.phaseTicks);
+                    StormboundIslesMod.LOGGER.info("Loaded game state from {}: Phase={}, Ticks={}",
+                            gameStatePath.getFileName(), gameState.phase, gameState.phaseTicks);
+                } else {
+                    StormboundIslesMod.LOGGER.warn("Game state file {} was empty or contained invalid data. Using default game state.", gameStatePath.getFileName());
+                    GameManager.setPhaseWithoutReset(GamePhase.LOBBY, 0);
+                }
+            } catch (IOException e) {
+                StormboundIslesMod.LOGGER.error("Could not read game state file: {}", gameStatePath, e);
+            } catch (JsonParseException e) {
+                StormboundIslesMod.LOGGER.error("Invalid JSON format in game state file: {}", gameStatePath, e);
+            } catch (Exception e) {
+                StormboundIslesMod.LOGGER.error("Unexpected error loading game state from file: {}", gameStatePath, e);
+            }
+        } else {
+            StormboundIslesMod.LOGGER.info("Game state file {} not found. Game will start in default state (LOBBY).", gameStatePath.getFileName());
+            GameManager.setPhaseWithoutReset(GamePhase.LOBBY, 0);
+        }
+    }
+
+    /**
+     * Saves the current islands data to the specified JSON file.
+     *
+     * @param dataDir The data directory where the islands file should be saved. Must not be null.
+     */
+    private static void saveIslands(@NotNull Path dataDir) {
+        Path islandsPath = dataDir.resolve(ISLANDS_FILENAME);
+        writeJsonToFile(islandsPath, islands,
+                (success) -> StormboundIslesMod.LOGGER.debug("Saved {} islands to {}", islands.size(), islandsPath.getFileName()),
+                "islands"
+        );
+    }
+
+    /**
+     * Saves the current teams data to the specified JSON file.
+     *
+     * @param dataDir The data directory where the teams file should be saved. Must not be null.
+     */
+    private static void saveTeams(@NotNull Path dataDir) {
+        Path teamsPath = dataDir.resolve(TEAMS_FILENAME);
+        writeJsonToFile(teamsPath, teams,
+                (success) -> StormboundIslesMod.LOGGER.debug("Saved {} teams to {}", teams.size(), teamsPath.getFileName()),
+                "teams"
+        );
+    }
+
+    /**
+     * Saves the current game state data to the specified JSON file.
+     *
+     * @param dataDir The data directory where the game state file should be saved. Must not be null.
+     */
+    private static void saveGameState(@NotNull Path dataDir) {
+        Path gameStatePath = dataDir.resolve(GAME_STATE_FILENAME);
+        GameState gameState = new GameState(
+                GameManager.phase,
+                GameManager.getPhaseTicks()
+        );
+        writeJsonToFile(gameStatePath, gameState,
+                (success) -> StormboundIslesMod.LOGGER.debug("Saved game state to {}: Phase={}, Ticks={}",
+                        gameStatePath.getFileName(), gameState.phase, gameState.phaseTicks),
+                "game state"
+        );
+    }
+
+    /**
+     * Utility method to write an object as JSON to a file using Gson.
+     * Handles potential IO and JSON exceptions during the write process.
+     *
+     * @param path      The {@link Path} where the file should be written. Must not be null.
+     * @param object    The object to serialize to JSON.
+     * @param onSuccess Optional callback {@link Consumer} executed on successful write.
+     * @param dataType  A descriptive name of the data type being saved (for logging). Must not be null.
+     */
+    private static void writeJsonToFile(@NotNull Path path, @Nullable Object object, @Nullable Consumer<Boolean> onSuccess, @NotNull String dataType) {
+        try {
+            String json = GSON.toJson(object);
+
+            try (var writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+                writer.write(json);
+            }
+
+            if (onSuccess != null) {
+                onSuccess.accept(true);
+            }
+        } catch (IOException e) {
+            StormboundIslesMod.LOGGER.error("Failed to write {} data to file: {}", dataType, path, e);
+        } catch (JsonParseException e) {
+            StormboundIslesMod.LOGGER.error("Error generating JSON for {} data for file: {}", dataType, path, e);
+        } catch (Exception e) {
+            StormboundIslesMod.LOGGER.error("Unexpected error saving {} data to file: {}", dataType, path, e);
+        }
+    }
+
+    // --- Inner Classes ---
+
+    /**
+     * Simple Data Transfer Object (DTO) or Record for serializing/deserializing game state.
+     * Using a record for conciseness and immutability (Java 16+).
+     * If targeting lower Java versions, revert to a private static class with fields and constructor.
+     */
+    private record GameState(GamePhase phase, int phaseTicks) {
+    }
 }

--- a/src/main/java/de/nofelix/stormboundisles/disaster/DisasterManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/disaster/DisasterManager.java
@@ -70,13 +70,15 @@ public class DisasterManager {
 			}
 		}
 
-		// Schedule removal of the active disaster flag after a delay (5 seconds = 100 ticks)
+		// Schedule removal of the active disaster flag after a delay
+		// Use ConfigManager.getDisasterCooldownTicks() and convert to milliseconds (ticks * 50ms/tick)
+		long cooldownMillis = (long) ConfigManager.getDisasterCooldownTicks() * 50L;
 		new Timer().schedule(new TimerTask() {
 			@Override
 			public void run() {
 				activeDisasters.remove(disasterKey);
 			}
-		}, 100 * 50); // 100 ticks * 50ms per tick = 5000ms = 5 seconds
+		}, cooldownMillis);
 	}
 
 	/**
@@ -88,24 +90,28 @@ public class DisasterManager {
 	 * @param server The Minecraft server instance (needed for damage sources).
 	 */
 	private static void applyDisasterEffect(ServerPlayerEntity player, DisasterType type, MinecraftServer server) {
+		// Use ConfigManager.getDisasterEffectDurationTicks() for status effect durations
+		int duration = ConfigManager.getDisasterEffectDurationTicks();
 		switch (type) {
 			case METEOR:
-				player.damage(server.getOverworld().getDamageSources().generic(), 8.0F);
+				 // Use Disaster getter for meteor damage
+				player.damage(server.getOverworld().getDamageSources().generic(), ConfigManager.getDisasterMeteorDamage());
 				break;
 			case BLIZZARD:
-				player.setFrozenTicks(player.getFrozenTicks() + 200);
+				// Use Disaster getter for blizzard freeze ticks
+				player.setFrozenTicks(player.getFrozenTicks() + ConfigManager.getDisasterBlizzardFreezeTicks());
 				break;
 			case SANDSTORM:
 				player.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
-						net.minecraft.entity.effect.StatusEffects.BLINDNESS, 200, 0));
+						net.minecraft.entity.effect.StatusEffects.BLINDNESS, duration, 0));
 				break;
 			case SPORE:
 				player.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
-						net.minecraft.entity.effect.StatusEffects.POISON, 100, 0));
+						net.minecraft.entity.effect.StatusEffects.POISON, duration, 0));
 				break;
 			case CRYSTAL_STORM:
 				player.addStatusEffect(new net.minecraft.entity.effect.StatusEffectInstance(
-						net.minecraft.entity.effect.StatusEffects.LEVITATION, 60, 0));
+						net.minecraft.entity.effect.StatusEffects.LEVITATION, duration, 0));
 				break;
 		}
 	}

--- a/src/main/java/de/nofelix/stormboundisles/game/ScoreboardManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/game/ScoreboardManager.java
@@ -112,19 +112,17 @@ public class ScoreboardManager {
 	}
 
 	public static void updateAllScores() {
+		// Simplified check: If scoreboard or objective is null, log and return.
+		// Re-initialization is handled by the ServerTickEvents handler (lines 35-46).
 		if (scoreboard == null || objective == null) {
-			StormboundIslesMod.LOGGER.warn("Cannot update scores: Scoreboard or objective not initialized.");
-			if (currentServer != null) {
-				initialize(currentServer);
-				if (scoreboard == null || objective == null) return;
-			} else {
-				return;
-			}
+			StormboundIslesMod.LOGGER.warn("Cannot update scores: Scoreboard or objective not initialized. Re-initialization will be attempted by the tick handler.");
+			return;
 		}
 
 		for (Map.Entry<String, Team> entry : DataManager.getTeams().entrySet()) {
 			Team team = entry.getValue();
 			String displayName = getDisplayNameForTeam(team);
+			// Use getOrCreateScoreAccess for clarity if available, otherwise stick to getOrCreateScore
 			ScoreAccess score = scoreboard.getOrCreateScore(ScoreHolder.fromName(displayName), objective);
 			if (score != null) {
 				score.setScore(team.getPoints());

--- a/src/main/java/de/nofelix/stormboundisles/game/ScoreboardManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/game/ScoreboardManager.java
@@ -3,181 +3,306 @@ package de.nofelix.stormboundisles.game;
 import de.nofelix.stormboundisles.StormboundIslesMod;
 import de.nofelix.stormboundisles.data.DataManager;
 import de.nofelix.stormboundisles.data.Team;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.scoreboard.*;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 
 import java.util.Map;
 import java.util.UUID;
 
 /**
- * Manages the scoreboard display for the Stormbound Isles mod.
- * This class handles the creation, initialization, and updating of the
- * scoreboard objective that displays team points in the sidebar.
- * It ensures that team scores are correctly represented with appropriate
- * display names and colors.
+ * Manages the scoreboard display and team assignments for the Stormbound Isles mod.
+ * Handles scoreboard objectives for points and synchronizes Minecraft scoreboard teams
+ * with the custom team data stored in DataManager.
  */
 public class ScoreboardManager {
 	private static final String OBJECTIVE_NAME = "sbi_points";
 	private static Scoreboard scoreboard;
 	private static ScoreboardObjective objective;
+	private static MinecraftServer currentServer;
 
 	public static void register() {
-		net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.SERVER_STARTED.register(ScoreboardManager::initialize);
+		ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+			currentServer = server;
+			initialize(server);
+		});
 
-		net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents.END_SERVER_TICK.register(server -> {
+		ServerTickEvents.END_SERVER_TICK.register(server -> {
+			if (currentServer == null) currentServer = server;
+
 			if (server.getTicks() % 20 == 0) {
-				updateAllScores();
+				if (scoreboard != null && objective != null) {
+					updateAllScores();
+				} else if (currentServer != null) {
+					StormboundIslesMod.LOGGER.warn("Scoreboard or objective is null, attempting re-initialization.");
+					initialize(currentServer);
+				}
 			}
 		});
 
-		// Update team entries when a player joins
-		ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> updateAllTeams(server));
+		ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+			currentServer = server;
+			addPlayerToScoreboardTeamOnJoin(handler.player);
+		});
 
-		StormboundIslesMod.LOGGER.info("ScoreboardManager registered");
+		ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
+			currentServer = server;
+			removePlayerFromScoreboardTeamOnLeave(handler.player);
+		});
+
+		StormboundIslesMod.LOGGER.info("ScoreboardManager registered event listeners.");
 	}
 
-	/**
-	 * Initializes the scoreboard manager.
-	 * Gets the server scoreboard, removes any existing objective with the same name,
-	 * creates a new objective for team points, sets it to display in the sidebar,
-	 * and updates all team scores initially.
-	 *
-	 * @param server The Minecraft server instance.
-	 */
 	public static void initialize(MinecraftServer server) {
+		if (server == null) {
+			StormboundIslesMod.LOGGER.error("Cannot initialize ScoreboardManager: Server instance is null.");
+			return;
+		}
+		currentServer = server;
 		scoreboard = server.getScoreboard();
+		if (scoreboard == null) {
+			StormboundIslesMod.LOGGER.error("Cannot initialize ScoreboardManager: Scoreboard is null.");
+			return;
+		}
 
-		// Remove existing objective if present
+		StormboundIslesMod.LOGGER.info("Initializing Scoreboard...");
+
 		ScoreboardObjective existingObjective = scoreboard.getNullableObjective(OBJECTIVE_NAME);
 		if (existingObjective != null) {
 			scoreboard.removeObjective(existingObjective);
+			StormboundIslesMod.LOGGER.debug("Removed existing scoreboard objective: {}", OBJECTIVE_NAME);
 		}
 
-		// Create new objective
-		objective = scoreboard.addObjective(
-				OBJECTIVE_NAME,
-				ScoreboardCriterion.DUMMY,
-				Text.literal("§b§lStormbound Isles"),
-				ScoreboardCriterion.RenderType.INTEGER,
-				false, // displayAutoUpdate
-				null   // numberFormat
-		);
+		try {
+			objective = scoreboard.addObjective(
+					OBJECTIVE_NAME,
+					ScoreboardCriterion.DUMMY,
+					Text.literal("§b§lStormbound Isles"),
+					ScoreboardCriterion.RenderType.INTEGER,
+					true,
+					null
+			);
+			StormboundIslesMod.LOGGER.debug("Created scoreboard objective: {}", OBJECTIVE_NAME);
+		} catch (IllegalArgumentException e) {
+			objective = scoreboard.getNullableObjective(OBJECTIVE_NAME);
+			if (objective == null) {
+				StormboundIslesMod.LOGGER.error("Failed to create or get scoreboard objective: {}", OBJECTIVE_NAME, e);
+				return;
+			}
+			StormboundIslesMod.LOGGER.warn("Scoreboard objective {} already existed.", OBJECTIVE_NAME);
+		}
 
-		// Display objective in the sidebar slot
 		scoreboard.setObjectiveSlot(ScoreboardDisplaySlot.SIDEBAR, objective);
+		StormboundIslesMod.LOGGER.debug("Set objective {} to display in sidebar.", OBJECTIVE_NAME);
 
-		// Setup scoreboard teams for playerlist & chat formatting
-		setupScoreboardTeams(server);
-
-		// Update all team scores
+		setupScoreboardTeamProperties();
 		updateAllScores();
 
-		StormboundIslesMod.LOGGER.info("Scoreboard initialized");
+		StormboundIslesMod.LOGGER.debug("Assigning initially online players to scoreboard teams...");
+		for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+			addPlayerToScoreboardTeamOnJoin(player);
+		}
+
+		StormboundIslesMod.LOGGER.info("Scoreboard initialized successfully.");
 	}
 
-	/**
-	 * Updates all scores on the scoreboard.
-	 * Clears existing scores for the objective and then sets the score
-	 * for each team based on the current data in DataManager.
-	 */
 	public static void updateAllScores() {
-		if (scoreboard == null || objective == null) return;
-
-		// Remove all existing scores for this objective
-		for (ScoreHolder holder : scoreboard.getKnownScoreHolders()) {
-			// Check if the score belongs to our objective before removing
-			if (scoreboard.getScore(holder, objective) != null) {
-				scoreboard.removeScore(holder, objective);
+		if (scoreboard == null || objective == null) {
+			StormboundIslesMod.LOGGER.warn("Cannot update scores: Scoreboard or objective not initialized.");
+			if (currentServer != null) {
+				initialize(currentServer);
+				if (scoreboard == null || objective == null) return;
+			} else {
+				return;
 			}
 		}
 
-		// Set scores for all teams
 		for (Map.Entry<String, Team> entry : DataManager.getTeams().entrySet()) {
 			Team team = entry.getValue();
 			String displayName = getDisplayNameForTeam(team);
 			ScoreAccess score = scoreboard.getOrCreateScore(ScoreHolder.fromName(displayName), objective);
-			score.setScore(team.getPoints());
+			if (score != null) {
+				score.setScore(team.getPoints());
+			} else {
+				StormboundIslesMod.LOGGER.warn("Could not get or create score for display name: {}", displayName);
+			}
 		}
 	}
 
-	/**
-	 * Updates the score for a specific team on the scoreboard.
-	 *
-	 * @param teamName The name of the team whose score needs updating.
-	 */
 	public static void updateTeamScore(String teamName) {
-		if (scoreboard == null || objective == null) return;
+		if (scoreboard == null || objective == null) {
+			StormboundIslesMod.LOGGER.warn("Cannot update team score: Scoreboard or objective not initialized.");
+			return;
+		}
 
 		Team team = DataManager.getTeam(teamName);
-		if (team == null) return;
+		if (team == null) {
+			StormboundIslesMod.LOGGER.warn("Cannot update score for non-existent team: {}", teamName);
+			return;
+		}
 
 		String displayName = getDisplayNameForTeam(team);
 		ScoreAccess score = scoreboard.getOrCreateScore(ScoreHolder.fromName(displayName), objective);
-		score.setScore(team.getPoints());
-	}
-
-	/**
-	 * Gets the display name for a team, including color codes.
-	 *
-	 * @param team The team object.
-	 * @return The formatted display name string with color codes.
-	 */
-	private static String getDisplayNameForTeam(Team team) {
-		// Colored team names based on the name
-		return switch (team.getName()) {
-			case "VOLCANO" -> "§c" + team.getName();
-			case "ICE" -> "§b" + team.getName();
-			case "DESERT" -> "§e" + team.getName();
-			case "MUSHROOM" -> "§d" + team.getName();
-			case "CRYSTAL" -> "§9" + team.getName();
-			default -> team.getName(); // Default case without color
-		};
-	}
-
-	/**
-	 * Create or update scoreboard teams for each custom team.
-	 *
-	 * @param server The Minecraft server instance.
-	 */
-	private static void setupScoreboardTeams(MinecraftServer server) {
-		for (Map.Entry<String, Team> entry : DataManager.getTeams().entrySet()) {
-			String teamName = entry.getKey();
-			Team team = entry.getValue();
-
-			// Get or create the scoreboard team
-			net.minecraft.scoreboard.Team sbTeam = scoreboard.getTeam(teamName);
-			if (sbTeam == null) {
-				sbTeam = scoreboard.addTeam(teamName);
-			}
-
-			// Set display settings
-			sbTeam.setDisplayName(Text.literal(teamName));
-			sbTeam.setPrefix(Text.literal(getDisplayNameForTeam(team) + " §r"));
-
-			// Remove old members
-			for (String memberName : sbTeam.getPlayerList()) {
-				scoreboard.removeScoreHolderFromTeam(memberName, sbTeam);
-			}
-
-			// Add current members
-			for (UUID uuid : team.getMembers()) {
-				ServerPlayerEntity player = server.getPlayerManager().getPlayer(uuid);
-				if (player != null) {
-					scoreboard.addScoreHolderToTeam(player.getGameProfile().getName(), sbTeam);
-				}
-			}
+		if (score != null) {
+			score.setScore(team.getPoints());
+		} else {
+			StormboundIslesMod.LOGGER.warn("Could not get or create score for display name: {}", displayName);
 		}
 	}
 
-	/**
-	 * Rebuilds all scoreboard team assignments on the playerlist and chat.
-	 *
-	 * @param server The Minecraft server instance.
-	 */
+	private static void setupScoreboardTeamProperties() {
+		if (scoreboard == null) {
+			StormboundIslesMod.LOGGER.warn("Cannot setup scoreboard team properties: Scoreboard not initialized.");
+			return;
+		}
+		StormboundIslesMod.LOGGER.debug("Setting up scoreboard team properties...");
+
+		for (Map.Entry<String, Team> entry : DataManager.getTeams().entrySet()) {
+			String teamName = entry.getKey();
+			Team teamData = entry.getValue();
+
+			net.minecraft.scoreboard.Team sbTeam = scoreboard.getTeam(teamName);
+			if (sbTeam == null) {
+				sbTeam = scoreboard.addTeam(teamName);
+				StormboundIslesMod.LOGGER.debug("Created scoreboard team: {}", teamName);
+			} else {
+				StormboundIslesMod.LOGGER.debug("Updating properties for scoreboard team: {}", teamName);
+			}
+
+			sbTeam.setDisplayName(Text.literal(teamName));
+			Formatting color = getTeamColor(teamData);
+			sbTeam.setColor(color);
+			sbTeam.setPrefix(Text.literal("[").append(Text.literal(teamName).formatted(color)).append("] "));
+			sbTeam.setFriendlyFireAllowed(false);
+			sbTeam.setShowFriendlyInvisibles(true);
+		}
+		StormboundIslesMod.LOGGER.debug("Finished setting up scoreboard team properties.");
+	}
+
+	private static void addPlayerToScoreboardTeamOnJoin(ServerPlayerEntity player) {
+		if (scoreboard == null || player == null) {
+			StormboundIslesMod.LOGGER.warn("Cannot add player to scoreboard team: Scoreboard not initialized or player is null.");
+			return;
+		}
+
+		UUID playerUuid = player.getUuid();
+		String playerName = player.getGameProfile().getName();
+		String targetTeamName = null;
+
+		for (Team team : DataManager.getTeams().values()) {
+			if (team.getMembers().contains(playerUuid)) {
+				targetTeamName = team.getName();
+				break;
+			}
+		}
+
+		if (targetTeamName != null) {
+			net.minecraft.scoreboard.Team sbTeam = scoreboard.getTeam(targetTeamName);
+			if (sbTeam != null) {
+				if (!sbTeam.getPlayerList().contains(playerName)) {
+					scoreboard.addScoreHolderToTeam(playerName, sbTeam);
+					StormboundIslesMod.LOGGER.info("Added player {} to scoreboard team {}", playerName, targetTeamName);
+				} else {
+					StormboundIslesMod.LOGGER.debug("Player {} already in scoreboard team {}", playerName, targetTeamName);
+				}
+			} else {
+				StormboundIslesMod.LOGGER.warn("Scoreboard team {} not found for player {} (DataManager team exists). Re-running setup.", targetTeamName, playerName);
+				setupScoreboardTeamProperties();
+				sbTeam = scoreboard.getTeam(targetTeamName);
+				if (sbTeam != null) {
+					scoreboard.addScoreHolderToTeam(playerName, sbTeam);
+					StormboundIslesMod.LOGGER.info("Added player {} to scoreboard team {} after re-setup.", playerName, targetTeamName);
+				} else {
+					StormboundIslesMod.LOGGER.error("Failed to find/create scoreboard team {} even after re-setup.", targetTeamName);
+				}
+			}
+		} else {
+			StormboundIslesMod.LOGGER.debug("Player {} not found in any DataManager team. Ensuring removal from scoreboard teams.", playerName);
+			removePlayerFromAllScoreboardTeams(playerName);
+		}
+	}
+
+	private static void removePlayerFromScoreboardTeamOnLeave(ServerPlayerEntity player) {
+		if (scoreboard == null || player == null) {
+			return;
+		}
+		removePlayerFromAllScoreboardTeams(player.getGameProfile().getName());
+	}
+
+	private static void removePlayerFromAllScoreboardTeams(String playerName) {
+		if (scoreboard == null) return;
+
+		for (String teamName : DataManager.getTeams().keySet()) {
+			net.minecraft.scoreboard.Team sbTeam = scoreboard.getTeam(teamName);
+			if (sbTeam != null && sbTeam.getPlayerList().contains(playerName)) {
+				scoreboard.removeScoreHolderFromTeam(playerName, sbTeam);
+				StormboundIslesMod.LOGGER.info("Removed player {} from scoreboard team {}", playerName, teamName);
+			}
+		}
+
+		AbstractTeam playerTeam = scoreboard.getScoreHolderTeam(playerName);
+		if (playerTeam instanceof net.minecraft.scoreboard.Team && DataManager.getTeam(playerTeam.getName()) == null) {
+			scoreboard.removeScoreHolderFromTeam(playerName, (net.minecraft.scoreboard.Team) playerTeam);
+			StormboundIslesMod.LOGGER.info("Removed player {} from non-DataManager scoreboard team {}.", playerName, playerTeam.getName());
+		}
+	}
+
 	public static void updateAllTeams(MinecraftServer server) {
-		setupScoreboardTeams(server);
+		if (server == null) {
+			StormboundIslesMod.LOGGER.error("Cannot update all teams: Server instance is null.");
+			return;
+		}
+		currentServer = server;
+		if (scoreboard == null) {
+			StormboundIslesMod.LOGGER.warn("Scoreboard not initialized during updateAllTeams. Attempting initialization.");
+			initialize(server);
+			if (scoreboard == null) return;
+		}
+
+		StormboundIslesMod.LOGGER.info("Refreshing all scoreboard team properties and online player assignments...");
+
+		setupScoreboardTeamProperties();
+
+		for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+			AbstractTeam currentSbTeam = scoreboard.getScoreHolderTeam(player.getGameProfile().getName());
+			Team dataManagerTeam = getPlayerTeamFromDataManager(player.getUuid());
+
+			if (currentSbTeam instanceof net.minecraft.scoreboard.Team && (dataManagerTeam == null || !currentSbTeam.getName().equals(dataManagerTeam.getName()))) {
+				scoreboard.removeScoreHolderFromTeam(player.getGameProfile().getName(), (net.minecraft.scoreboard.Team) currentSbTeam);
+				StormboundIslesMod.LOGGER.debug("Removed player {} from incorrect scoreboard team {} during refresh.", player.getGameProfile().getName(), currentSbTeam.getName());
+			}
+
+			addPlayerToScoreboardTeamOnJoin(player);
+		}
+		StormboundIslesMod.LOGGER.info("Finished refreshing scoreboard teams.");
+	}
+
+	private static Team getPlayerTeamFromDataManager(UUID playerUuid) {
+		for (Team team : DataManager.getTeams().values()) {
+			if (team.getMembers().contains(playerUuid)) {
+				return team;
+			}
+		}
+		return null;
+	}
+
+	private static String getDisplayNameForTeam(Team team) {
+		return getTeamColor(team) + team.getName();
+	}
+
+	private static Formatting getTeamColor(Team team) {
+		return switch (team.getName().toUpperCase()) {
+			case "VOLCANO" -> Formatting.RED;
+			case "ICE" -> Formatting.AQUA;
+			case "DESERT" -> Formatting.YELLOW;
+			case "MUSHROOM" -> Formatting.LIGHT_PURPLE;
+			case "CRYSTAL" -> Formatting.BLUE;
+			default -> Formatting.WHITE;
+		};
 	}
 }

--- a/src/main/java/de/nofelix/stormboundisles/handler/BuffAuraHandler.java
+++ b/src/main/java/de/nofelix/stormboundisles/handler/BuffAuraHandler.java
@@ -20,7 +20,6 @@ import java.util.Optional;
  */
 public class BuffAuraHandler {
 	private static final long LOG_INTERVAL = 10_000L;
-	private static final int BUFF_DURATION_TICKS = 80;
 	private static final boolean AMBIENT = false;
 	private static final boolean SHOW_PARTICLES = true;
 
@@ -83,17 +82,18 @@ public class BuffAuraHandler {
 	 * @param type   the island type determining the buff
 	 */
 	private static void applyBuff(ServerPlayerEntity player, IslandType type) {
+		int duration = ConfigManager.getBuffDurationTicks();
 		StatusEffectInstance effect = switch (type) {
 			case DESERT ->
-					new StatusEffectInstance(StatusEffects.SPEED, BUFF_DURATION_TICKS, 0, true, AMBIENT, SHOW_PARTICLES);
+					new StatusEffectInstance(StatusEffects.SPEED, duration, 0, true, AMBIENT, SHOW_PARTICLES);
 			case VOLCANO ->
-					new StatusEffectInstance(StatusEffects.FIRE_RESISTANCE, BUFF_DURATION_TICKS, 0, true, AMBIENT, SHOW_PARTICLES);
+					new StatusEffectInstance(StatusEffects.FIRE_RESISTANCE, duration, 0, true, AMBIENT, SHOW_PARTICLES);
 			case ICE ->
-					new StatusEffectInstance(StatusEffects.RESISTANCE, BUFF_DURATION_TICKS, 0, true, AMBIENT, SHOW_PARTICLES);
+					new StatusEffectInstance(StatusEffects.RESISTANCE, duration, 0, true, AMBIENT, SHOW_PARTICLES);
 			case MUSHROOM ->
-					new StatusEffectInstance(StatusEffects.REGENERATION, BUFF_DURATION_TICKS, 0, true, AMBIENT, SHOW_PARTICLES);
+					new StatusEffectInstance(StatusEffects.REGENERATION, duration, 0, true, AMBIENT, SHOW_PARTICLES);
 			case CRYSTAL ->
-					new StatusEffectInstance(StatusEffects.HASTE, BUFF_DURATION_TICKS, 0, true, AMBIENT, SHOW_PARTICLES);
+					new StatusEffectInstance(StatusEffects.HASTE, duration, 0, true, AMBIENT, SHOW_PARTICLES);
 		};
 		player.addStatusEffect(effect);
 	}


### PR DESCRIPTION
- Centralizes game constants like phase durations, penalties, and buff/disaster settings into a restructured `ConfigManager`.
- Improves config file loading robustness and enables pretty-printing.
- Fixes player scoreboard team assignments to persist correctly when players rejoin the server.
- Refactors `ScoreboardManager` to use join/leave events for managing team membership.
- Enhances `DataManager` with thread-safe collections and improved file I/O handling.

Fixes #10 