### PR TITLE
🩹 avoid duplicate 'Team:' and 'Island:' prefixes in player info

### DIFF
--- a/src/main/java/de/nofelix/stormboundisles/command/categories/PlayerCommands.java
+++ b/src/main/java/de/nofelix/stormboundisles/command/categories/PlayerCommands.java
@@ -96,12 +96,12 @@ public class PlayerCommands implements CommandCategory {
         String teamInfo = Constants.NO_TEAM;
         for (Team team : DataManager.getTeams().values()) {
             if (team.getMembers().contains(player.getUuid())) {
-                teamInfo = Constants.TEAM_PREFIX + team.getName() + Constants.RESET;
+                teamInfo = team.getName();
                 break;
             }
         }
 
-        sb.append(Constants.TEAM_PREFIX).append(teamInfo).append("\n");
+        sb.append(Constants.TEAM_PREFIX).append(teamInfo).append(Constants.RESET).append("\n");
         sb.append(Constants.POSITION_PREFIX).append(player.getBlockPos().getX())
                 .append(", ").append(player.getBlockPos().getY())
                 .append(", ").append(player.getBlockPos().getZ())
@@ -111,11 +111,11 @@ public class PlayerCommands implements CommandCategory {
         String currentIsland = Constants.NO_ISLAND;
         for (Island island : DataManager.getIslands().values()) {
             if (island.getZone() != null && island.getZone().contains(player.getBlockPos())) {
-                currentIsland = Constants.ISLAND_PREFIX + island.getId() + Constants.RESET;
+                currentIsland = island.getId();
                 break;
             }
         }
-        sb.append(Constants.ISLAND_PREFIX).append(currentIsland);
+        sb.append(Constants.ISLAND_PREFIX).append(currentIsland).append(Constants.RESET);
 
         ctx.getSource().sendFeedback(() -> Text.literal(sb.toString()), false);
         return 1;


### PR DESCRIPTION
Fixes a bug where the `player info` command printed the `Team:` and `Island:` prefixes twice (e.g. `Island: Island: AURALIS`).

Change:
- `PlayerCommands.displayPlayerInfo` now stores raw team name and island id and appends the prefix and reset exactly once.

Behavior:
- No functional changes apart from message formatting. Moderators still see full info as before.

Please review and merge into `develop`.

Closes #17