### PR TITLE
add proper boundary enforcement

### DIFF
--- a/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
@@ -41,6 +41,8 @@ public final class ConfigManager {
         static final int PVP_PHASE_TICKS = 20 * 60 * 60 * 24 * 7; // 1 week
         static final int COUNTDOWN_DURATION_TICKS = 20 * 10; // 10 seconds
         static final int BOUNDARY_CHECK_INTERVAL = 10;
+        static final double BOUNDARY_PUSH_STEP = 1.0;
+        static final int BOUNDARY_PUSH_MAX_STEPS = 10;
         static final int DEATH_PENALTY = 10;
         static final long BOUNDARY_WARNING_COOLDOWN_MS = 3000L;
         static final long RESET_CONFIRMATION_TIMEOUT_MS = 10000L;
@@ -159,6 +161,8 @@ public final class ConfigManager {
         LOGGER.info("  Player: Boundary check {}t, Death penalty {}, Warning cooldown {}ms",
                 config.player.boundaryCheckInterval, config.player.deathPenalty,
                 config.player.boundaryWarningCooldownMs);
+        LOGGER.info("    Boundary push step {} blocks, max attempts {}",
+                config.player.boundaryPushStep, config.player.boundaryPushMaxSteps);
         LOGGER.info("  Buffs: Update interval {}t, Duration {}t",
                 config.buff.buffUpdateInterval, config.buff.buffDurationTicks);
         LOGGER.info("  Scoreboard: Update interval {}t",
@@ -204,6 +208,19 @@ public final class ConfigManager {
         if (config.player.deathPenalty < 0 || config.player.deathPenalty > 1000) { // Reasonable max
             config.player.deathPenalty = Defaults.DEATH_PENALTY;
             LOGGER.warn("Invalid deathPenalty, reset to default: {}", config.player.deathPenalty);
+            corrected = true;
+        }
+
+        // Validate boundary push settings
+        if (config.player.boundaryPushStep <= 0.0 || config.player.boundaryPushStep > 100.0) {
+            config.player.boundaryPushStep = Defaults.BOUNDARY_PUSH_STEP;
+            LOGGER.warn("Invalid boundaryPushStep, reset to default: {}", config.player.boundaryPushStep);
+            corrected = true;
+        }
+
+        if (config.player.boundaryPushMaxSteps <= 0 || config.player.boundaryPushMaxSteps > 100) {
+            config.player.boundaryPushMaxSteps = Defaults.BOUNDARY_PUSH_MAX_STEPS;
+            LOGGER.warn("Invalid boundaryPushMaxSteps, reset to default: {}", config.player.boundaryPushMaxSteps);
             corrected = true;
         }
 
@@ -294,6 +311,15 @@ public final class ConfigManager {
         return config.player.resetConfirmationTimeoutMs;
     }
 
+    // New player push-back getters
+    public static double getPlayerBoundaryPushStep() {
+        return config.player.boundaryPushStep;
+    }
+
+    public static int getPlayerBoundaryPushMaxSteps() {
+        return config.player.boundaryPushMaxSteps;
+    }
+
     // Buff settings getters
     public static int getBuffUpdateInterval() {
         return config.buff.buffUpdateInterval;
@@ -377,6 +403,10 @@ public final class ConfigManager {
              * data reset. Default: 10000ms (10 seconds).
              */
             long resetConfirmationTimeoutMs = Defaults.RESET_CONFIRMATION_TIMEOUT_MS;
+            /** How far to push a player back per corrective step (blocks). */
+            double boundaryPushStep = Defaults.BOUNDARY_PUSH_STEP;
+            /** Maximum number of corrective push attempts. */
+            int boundaryPushMaxSteps = Defaults.BOUNDARY_PUSH_MAX_STEPS;
         }
 
         /**

--- a/src/main/java/de/nofelix/stormboundisles/handler/PlayerEventHandler.java
+++ b/src/main/java/de/nofelix/stormboundisles/handler/PlayerEventHandler.java
@@ -10,9 +10,11 @@ import de.nofelix.stormboundisles.game.GamePhase;
 import de.nofelix.stormboundisles.game.ScoreboardManager;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 
@@ -45,6 +47,14 @@ public final class PlayerEventHandler {
 			}
 		});
 		ServerTickEvents.END_SERVER_TICK.register(PlayerEventHandler::onServerTick);
+
+		// Clean up boundary warning timestamps when players disconnect to avoid
+		// unbounded growth of the map.
+		ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
+			if (handler != null && handler.getPlayer() != null) {
+				lastBoundaryWarning.remove(handler.getPlayer().getUuid());
+			}
+		});
 	}
 
 	/**
@@ -79,25 +89,124 @@ public final class PlayerEventHandler {
 		if (island == null || island.getZone() == null)
 			return;
 
+		ServerWorld world = player.getServerWorld();
+
+		// Don't enforce boundaries in other dimensions
+		if (world.getRegistryKey() != World.OVERWORLD) {
+			StormboundIslesMod.LOGGER.debug("Skipping boundary enforcement for player {} in dimension {}",
+					player.getName().getString(), world.getRegistryKey().getValue());
+			return;
+		}
+
 		BlockPos pos = player.getBlockPos();
 		if (!island.getZone().contains(pos)) {
 			long now = System.currentTimeMillis();
 			Long last = lastBoundaryWarning.get(player.getUuid());
 			if (last == null || (now - last) > ConfigManager.getPlayerBoundaryWarningCooldownMs()) {
-				player.sendMessage(
-						Text.literal("§c⚠ You cannot leave your island during the build phase!"),
-						true);
+				player.sendMessage(Text.literal("§c⚠ You cannot leave your island during the build phase!"), true);
 				lastBoundaryWarning.put(player.getUuid(), now);
+				StormboundIslesMod.LOGGER.debug("Warning sent to player {} for leaving island {}",
+						player.getName().getString(), team.get().getIslandId());
 			}
 
 			if (island.getSpawnY() >= 0) {
-				ServerWorld world = player.getServerWorld();
-				player.teleport(
-						world,
-						island.getSpawnX() + 0.5, island.getSpawnY(), island.getSpawnZ() + 0.5,
-						player.getYaw(), player.getPitch());
+
+				double px = player.getX();
+				double pz = player.getZ();
+				double sx = island.getSpawnX() + 0.5;
+				double sz = island.getSpawnZ() + 0.5;
+				double dx = px - sx;
+				double dz = pz - sz;
+				double len = Math.sqrt(dx * dx + dz * dz);
+
+				final double pushStep = ConfigManager.getPlayerBoundaryPushStep();
+				final int maxSteps = ConfigManager.getPlayerBoundaryPushMaxSteps();
+				boolean moved = false;
+
+				if (len <= 0.0001) {
+					double py = player.getY();
+					player.teleport(world, sx, py, sz, player.getYaw(), player.getPitch());
+					moved = true;
+				} else {
+					for (int i = 1; i <= maxSteps; i++) {
+						double newLen = Math.max(0.0, len - pushStep * i);
+						double nx = sx + (dx / len) * newLen;
+						double nz = sz + (dz / len) * newLen;
+
+						int cx = (int) Math.floor(nx);
+						int cz = (int) Math.floor(nz);
+						int cy = (int) Math.floor(player.getY());
+
+						BlockPos candidate = new BlockPos(cx, cy, cz);
+						if (island.getZone().contains(candidate)) {
+							// Try small vertical adjustments before rejecting candidate
+							double[] offsets = { 0.0, 1.0, -1.0, 2.0, -2.0 };
+							boolean teleported = false;
+							for (double off : offsets) {
+								double tryY = player.getY() + off;
+								if (isSafeTeleport(world, nx, tryY, nz)) {
+									player.teleport(world, nx, tryY, nz, player.getYaw(), player.getPitch());
+									StormboundIslesMod.LOGGER.debug("Pushed player {} back to {} (island {})",
+											player.getName().getString(), new BlockPos(cx, (int) Math.floor(tryY), cz),
+											team.get().getIslandId());
+									moved = true;
+									teleported = true;
+									break;
+								}
+							}
+							if (teleported)
+								break;
+						}
+					}
+				}
+
+				if (!moved) {
+					// Try fallback spawn teleport if it's safe
+					// Try small vertical adjustments around spawn
+					double[] offsets = { 0.0, 1.0, -1.0, 2.0, -2.0 };
+					boolean teleported = false;
+					for (double off : offsets) {
+						double tryY = island.getSpawnY() + off;
+						if (isSafeTeleport(world, sx, tryY, sz)) {
+							player.teleport(world, sx, tryY, sz, player.getYaw(), player.getPitch());
+							StormboundIslesMod.LOGGER.debug(
+									"Fallback teleport of player {} to spawn of island {} at {}",
+									player.getName().getString(), team.get().getIslandId(),
+									new BlockPos((int) sx, (int) Math.floor(tryY), (int) sz));
+							teleported = true;
+							break;
+						}
+					}
+					if (!teleported) {
+						StormboundIslesMod.LOGGER.warn(
+								"Could not safely teleport player {} to spawn of island {} (unsafe blocks at destination)",
+								player.getName().getString(), team.get().getIslandId());
+						player.sendMessage(Text.literal(
+								"§cCould not safely teleport you back to your island. Please contact an admin."), true);
+					}
+				}
 			}
 		}
+	}
+
+	private static boolean isSafeTeleport(ServerWorld world, double x, double y, double z) {
+		BlockPos target = new BlockPos((int) Math.floor(x), (int) Math.floor(y), (int) Math.floor(z));
+		BlockPos above = target.up();
+		BlockPos below = target.down();
+
+		// Destination and one block above must be air
+		if (!world.getBlockState(target).isAir())
+			return false;
+		if (!world.getBlockState(above).isAir())
+			return false;
+
+		// Block below must exist and not be liquid
+		if (world.getBlockState(below).isAir())
+			return false;
+		if (!world.getFluidState(below).isEmpty())
+			return false;
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces a configurable and safer mechanism for enforcing island boundaries during the build phase. The main improvements include adding new configuration options to control how far and how many times a player can be pushed back toward their island, and updating the boundary enforcement logic to use these settings. Additionally, the code now ensures cleanup of player-related warning data on disconnects and includes more robust checks for safe teleportation.

**Configurable boundary enforcement:**
* Added two new configuration options: `boundaryPushStep` (distance per push-back attempt) and `boundaryPushMaxSteps` (maximum number of attempts), with validation and logging to ensure safe and reasonable values. [[1]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R44-R45) [[2]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R164-R165) [[3]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R214-R226) [[4]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R314-R322) [[5]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R406-R409)

**Boundary enforcement logic improvements:**
* Updated `enforceIslandBoundary` to use the new push-back mechanism, attempting to move the player back in configurable steps and directions, with multiple vertical safety checks before fallback to spawn teleportation. Added logging for all actions and failures.

**Safety and cleanup:**
* Added a helper method `isSafeTeleport` to check if a teleport destination is safe (air blocks above, solid ground below, no liquid).
* Added cleanup of boundary warning timestamps when players disconnect to prevent memory leaks.

**Dimension checks:**
* Boundary enforcement now only applies in the Overworld, skipping other dimensions with debug logging.