### PR TITLE
✨ add kill reward configuration and logic for player kills; enhance player death handling

### DIFF
--- a/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/config/ConfigManager.java
@@ -44,6 +44,7 @@ public final class ConfigManager {
         static final double BOUNDARY_PUSH_STEP = 1.0;
         static final int BOUNDARY_PUSH_MAX_STEPS = 10;
         static final int DEATH_PENALTY = 10;
+        static final int KILL_REWARD = 5;
         static final long BOUNDARY_WARNING_COOLDOWN_MS = 3000L;
         static final long RESET_CONFIRMATION_TIMEOUT_MS = 10000L;
         static final int BUFF_UPDATE_INTERVAL = 60;
@@ -161,6 +162,8 @@ public final class ConfigManager {
         LOGGER.info("  Player: Boundary check {}t, Death penalty {}, Warning cooldown {}ms",
                 config.player.boundaryCheckInterval, config.player.deathPenalty,
                 config.player.boundaryWarningCooldownMs);
+        LOGGER.info("    Kill reward {}",
+                config.player.killReward);
         LOGGER.info("    Boundary push step {} blocks, max attempts {}",
                 config.player.boundaryPushStep, config.player.boundaryPushMaxSteps);
         LOGGER.info("  Buffs: Update interval {}t, Duration {}t",
@@ -179,7 +182,19 @@ public final class ConfigManager {
     private static void validateAndCorrectConfig() {
         boolean corrected = false;
 
-        // Validate game settings with reasonable bounds
+        corrected |= validateGameSettings();
+        corrected |= validatePlayerSettings();
+        corrected |= validateBuffSettings();
+        corrected |= validateScoreboardSettings();
+        corrected |= validateDisasterSettings();
+
+        if (corrected) {
+            saveConfig();
+        }
+    }
+
+    private static boolean validateGameSettings() {
+        boolean corrected = false;
         if (config.game.buildPhaseTicks <= 0 || config.game.buildPhaseTicks > Integer.MAX_VALUE / 2) {
             config.game.buildPhaseTicks = Defaults.BUILD_PHASE_TICKS;
             LOGGER.warn("Invalid buildPhaseTicks, reset to default: {}", config.game.buildPhaseTicks);
@@ -198,7 +213,11 @@ public final class ConfigManager {
             corrected = true;
         }
 
-        // Validate player settings with reasonable bounds
+        return corrected;
+    }
+
+    private static boolean validatePlayerSettings() {
+        boolean corrected = false;
         if (config.player.boundaryCheckInterval <= 0 || config.player.boundaryCheckInterval > 20 * 60) { // Max 1 minute
             config.player.boundaryCheckInterval = Defaults.BOUNDARY_CHECK_INTERVAL;
             LOGGER.warn("Invalid boundaryCheckInterval, reset to default: {}", config.player.boundaryCheckInterval);
@@ -211,7 +230,12 @@ public final class ConfigManager {
             corrected = true;
         }
 
-        // Validate boundary push settings
+        if (config.player.killReward < 0 || config.player.killReward > 1000) { // Reasonable max
+            config.player.killReward = Defaults.KILL_REWARD;
+            LOGGER.warn("Invalid killReward, reset to default: {}", config.player.killReward);
+            corrected = true;
+        }
+
         if (config.player.boundaryPushStep <= 0.0 || config.player.boundaryPushStep > 100.0) {
             config.player.boundaryPushStep = Defaults.BOUNDARY_PUSH_STEP;
             LOGGER.warn("Invalid boundaryPushStep, reset to default: {}", config.player.boundaryPushStep);
@@ -224,7 +248,11 @@ public final class ConfigManager {
             corrected = true;
         }
 
-        // Validate buff settings
+        return corrected;
+    }
+
+    private static boolean validateBuffSettings() {
+        boolean corrected = false;
         if (config.buff.buffUpdateInterval <= 0 || config.buff.buffUpdateInterval > 20 * 60) { // Max 1 minute
             config.buff.buffUpdateInterval = Defaults.BUFF_UPDATE_INTERVAL;
             LOGGER.warn("Invalid buffUpdateInterval, reset to default: {}", config.buff.buffUpdateInterval);
@@ -237,14 +265,21 @@ public final class ConfigManager {
             corrected = true;
         }
 
-        // Validate scoreboard settings
+        return corrected;
+    }
+
+    private static boolean validateScoreboardSettings() {
+        boolean corrected = false;
         if (config.scoreboard.updateInterval <= 0 || config.scoreboard.updateInterval > 20 * 60) { // Max 1 minute
             config.scoreboard.updateInterval = Defaults.SCOREBOARD_UPDATE_INTERVAL;
             LOGGER.warn("Invalid scoreboard updateInterval, reset to default: {}", config.scoreboard.updateInterval);
             corrected = true;
         }
+        return corrected;
+    }
 
-        // Validate disaster settings
+    private static boolean validateDisasterSettings() {
+        boolean corrected = false;
         if (config.disaster.disasterIntervalTicks <= 0 || config.disaster.disasterIntervalTicks > 20 * 60 * 60) { // Max
                                                                                                                   // 1
                                                                                                                   // hour
@@ -259,9 +294,7 @@ public final class ConfigManager {
             corrected = true;
         }
 
-        if (corrected) {
-            saveConfig();
-        }
+        return corrected;
     }
 
     /**
@@ -305,6 +338,10 @@ public final class ConfigManager {
 
     public static long getPlayerBoundaryWarningCooldownMs() {
         return config.player.boundaryWarningCooldownMs;
+    }
+
+    public static int getPlayerKillReward() {
+        return config.player.killReward;
     }
 
     public static long getPlayerResetConfirmationTimeoutMs() {
@@ -407,6 +444,11 @@ public final class ConfigManager {
             double boundaryPushStep = Defaults.BOUNDARY_PUSH_STEP;
             /** Maximum number of corrective push attempts. */
             int boundaryPushMaxSteps = Defaults.BOUNDARY_PUSH_MAX_STEPS;
+            /**
+             * Points awarded to a team when a member kills a player from a different
+             * island. Default: 5 points.
+             */
+            int killReward = Defaults.KILL_REWARD;
         }
 
         /**

--- a/src/main/java/de/nofelix/stormboundisles/game/ScoreboardManager.java
+++ b/src/main/java/de/nofelix/stormboundisles/game/ScoreboardManager.java
@@ -549,7 +549,7 @@ public class ScoreboardManager {
 	 * @param team The team to generate a display name for
 	 * @return Formatted display name
 	 */
-	private static String getDisplayNameForTeam(Team team) {
+	public static String getDisplayNameForTeam(Team team) {
 		return getTeamColor(team) + team.getName();
 	}
 
@@ -559,7 +559,7 @@ public class ScoreboardManager {
 	 * @param team The team to get color for
 	 * @return The formatting color for the team
 	 */
-	private static Formatting getTeamColor(Team team) {
+	public static Formatting getTeamColor(Team team) {
 		return switch (team.getName().toUpperCase()) {
 			case "PYROTHAR" -> Formatting.RED;
 			case "FROSTREIGN" -> Formatting.AQUA;

--- a/src/main/java/de/nofelix/stormboundisles/handler/PlayerEventHandler.java
+++ b/src/main/java/de/nofelix/stormboundisles/handler/PlayerEventHandler.java
@@ -17,11 +17,15 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.World;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import net.minecraft.util.Formatting;
 
 /**
  * Handles player-related events: death penalties and boundary enforcement
@@ -34,6 +38,18 @@ public final class PlayerEventHandler {
 	private PlayerEventHandler() {
 	}
 
+	private static Formatting getTeamColor(Team team) {
+		if (team == null)
+			return Formatting.WHITE;
+		return switch (team.getName().toUpperCase()) {
+			case "PYROTHAR" -> Formatting.RED;
+			case "FROSTREIGN" -> Formatting.AQUA;
+			case "SAHRAKIR" -> Formatting.YELLOW;
+			case "AURALIS" -> Formatting.LIGHT_PURPLE;
+			default -> Formatting.WHITE;
+		};
+	}
+
 	/**
 	 * Registers death and tick listeners.
 	 */
@@ -43,7 +59,7 @@ public final class PlayerEventHandler {
 			if (entity instanceof ServerPlayerEntity player) {
 				StormboundIslesMod.LOGGER.info(
 						"Player {} died, handling death event.", player.getName().getString());
-				handlePlayerDeath(player);
+				handlePlayerDeath(player, src);
 			}
 		});
 		ServerTickEvents.END_SERVER_TICK.register(PlayerEventHandler::onServerTick);
@@ -212,9 +228,8 @@ public final class PlayerEventHandler {
 	/**
 	 * Applies point penalty on player death during BUILD or PVP phases.
 	 */
-	private static void handlePlayerDeath(ServerPlayerEntity player) {
-		if (GameManager.phase != GamePhase.BUILD
-				&& GameManager.phase != GamePhase.PVP) {
+	private static void handlePlayerDeath(ServerPlayerEntity player, DamageSource src) {
+		if (GameManager.phase != GamePhase.BUILD && GameManager.phase != GamePhase.PVP) {
 			return;
 		}
 
@@ -224,42 +239,181 @@ public final class PlayerEventHandler {
 				.findFirst();
 
 		team.ifPresent(t -> {
-			int penalty = ConfigManager.getPlayerDeathPenalty();
-			t.addPoints(-penalty);
-			ScoreboardManager.updateTeamScore(t.getName());
-
-			String msg = "Team " + t.getName() + " lost " + penalty +
-					" points (Player death: " + player.getName().getString() + ")";
-			StormboundIslesMod.LOGGER.info(msg);
-			player.getServer()
-					.getPlayerManager()
-					.broadcast(Text.literal(msg), false);
-
-			DataManager.saveAll();
-			Island isl = DataManager.getIsland(t.getIslandId());
-
-			// Only revive and force-teleport players during the BUILD phase.
-			// In PVP phase (or other phases) we leave the normal death behavior intact
-			// so players remain dead on hardcore servers.
-			if (isl != null && isl.hasSpawnPoint() && GameManager.phase == GamePhase.BUILD) {
-				ServerWorld world = player.getServerWorld();
-				int tx = isl.getSpawnX();
-				int ty = isl.getSpawnY();
-				int tz = isl.getSpawnZ();
-
-				player.teleport(world, tx + 0.5, ty, tz + 0.5, player.getYaw(), player.getPitch());
-
-				// Revive
-				try {
-					player.setHealth(player.getMaxHealth());
-				} catch (Throwable ex) {
-					StormboundIslesMod.LOGGER.warn("Failed to set health for player {}: {}",
-							player.getName().getString(), ex.getMessage());
-				}
-
-				// Safety
-				player.teleport(world, tx + 0.5, ty, tz + 0.5, player.getYaw(), player.getPitch());
-			}
+			applyDeathPenalty(t, player);
+			awardKillReward(t, player, src);
+			reviveAndTeleportPlayer(t, player);
 		});
+	}
+
+	/**
+	 * Applies the configured death penalty to the victim's team and broadcasts it.
+	 */
+	private static void applyDeathPenalty(Team victimTeam, ServerPlayerEntity victim) {
+		int penalty = ConfigManager.getPlayerDeathPenalty();
+		victimTeam.addPoints(-penalty);
+		ScoreboardManager.updateTeamScore(victimTeam.getName());
+
+		// Format: Team <colored-name> lost <points> points (Player
+		// death: <player>)
+		String coloredTeam = getTeamColor(victimTeam) + "Team " + victimTeam.getName() + Formatting.RESET;
+		String msg = coloredTeam + " lost §e" + penalty +
+				" §cpoints §7(§ePlayer death: §f" + victim.getName().getString() + "§7)";
+		StormboundIslesMod.LOGGER.info("Death broadcast: {}", msg);
+		victim.getServer().getPlayerManager().broadcast(Text.literal(msg), false);
+
+		DataManager.saveAll();
+	}
+
+	/**
+	 * Awards the configurable kill reward to the killer's team if the killer was a
+	 * player
+	 * and is from a different island/team than the victim.
+	 */
+	private static void awardKillReward(Team victimTeam, ServerPlayerEntity victim, DamageSource src) {
+		try {
+			Optional<ServerPlayerEntity> maybeKiller = resolveKillerFromDamageSource(src, victim);
+			if (maybeKiller.isEmpty())
+				return;
+
+			ServerPlayerEntity killer = maybeKiller.get();
+			UUID kid = killer.getUuid();
+			Optional<Team> kteam = DataManager.getTeams().values().stream()
+					.filter(x -> x.getMembers().contains(kid))
+					.findFirst();
+
+			kteam.ifPresent(kt -> {
+				// Only award if killer is from a different island/team
+				if (kt.getIslandId() == null || !kt.getIslandId().equals(victimTeam.getIslandId())) {
+					int reward = ConfigManager.getPlayerKillReward();
+					kt.addPoints(reward);
+					ScoreboardManager.updateTeamScore(kt.getName());
+					// Format: Team <colored-name> gained <points> points (Kill:
+					// <player>)
+					String kcoloredTeam = getTeamColor(kt) + "Team " + kt.getName() + Formatting.RESET;
+					String kmsg = kcoloredTeam + " gained §e" + reward +
+							" §apoints §7(§eKill: §f" + killer.getName().getString() + "§7)";
+					StormboundIslesMod.LOGGER.info("Kill broadcast: {}", kmsg);
+					victim.getServer().getPlayerManager().broadcast(Text.literal(kmsg), false);
+					DataManager.saveAll();
+				}
+			});
+		} catch (Exception e) {
+			StormboundIslesMod.LOGGER.warn("Failed to resolve owner via getOwner on attacker: {}", e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Revives and teleports the victim back to their island spawn during BUILD
+	 * phase if configured.
+	 */
+	private static void reviveAndTeleportPlayer(Team victimTeam, ServerPlayerEntity victim) {
+		if (GameManager.phase != GamePhase.BUILD)
+			return;
+
+		Island isl = DataManager.getIsland(victimTeam.getIslandId());
+		if (isl == null || !isl.hasSpawnPoint())
+			return;
+
+		ServerWorld world = victim.getServerWorld();
+		int tx = isl.getSpawnX();
+		int ty = isl.getSpawnY();
+		int tz = isl.getSpawnZ();
+
+		// Teleport to spawn
+		victim.teleport(world, tx + 0.5, ty, tz + 0.5, victim.getYaw(), victim.getPitch());
+
+		// Revive (best effort)
+		try {
+			victim.setHealth(victim.getMaxHealth());
+		} catch (Exception e) {
+			StormboundIslesMod.LOGGER.warn("Failed to resolve owner via getOwnerUuid on attacker: {}", e.getMessage());
+			e.printStackTrace();
+		}
+
+		// Safety repeat teleport
+		victim.teleport(world, tx + 0.5, ty, tz + 0.5, victim.getYaw(), victim.getPitch());
+	}
+
+	/**
+	 * Try to call a no-arg getOwner() on the attacker and return a player owner if
+	 * present.
+	 */
+	private static Optional<ServerPlayerEntity> getOwnerEntityViaGetOwner(Entity attacker) {
+		if (attacker == null)
+			return Optional.empty();
+		try {
+			Method m = attacker.getClass().getMethod("getOwner");
+			Object owner = m.invoke(attacker);
+			if (owner instanceof ServerPlayerEntity serverOwner)
+				return Optional.of(serverOwner);
+			if (owner instanceof Entity ent && ent instanceof ServerPlayerEntity serverOwner2)
+				return Optional.of(serverOwner2);
+		} catch (NoSuchMethodException | SecurityException ignored) {
+			// Method not present on this attacker type, that's fine.
+		} catch (Exception e) {
+			StormboundIslesMod.LOGGER.debug("getOwner reflection failed: {}", e.getMessage());
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * Try to call getOwnerUuid() on the attacker and resolve an online player by
+	 * UUID.
+	 */
+	private static Optional<ServerPlayerEntity> getOwnerEntityViaGetOwnerUuid(Entity attacker,
+			ServerPlayerEntity victim) {
+		if (attacker == null || victim == null)
+			return Optional.empty();
+		try {
+			Method m2 = attacker.getClass().getMethod("getOwnerUuid");
+			Object val = m2.invoke(attacker);
+			if (val instanceof UUID uuid) {
+				ServerPlayerEntity p = victim.getServer().getPlayerManager().getPlayer(uuid);
+				if (p != null)
+					return Optional.of(p);
+			} else if (val instanceof String s) {
+				try {
+					UUID uuid = UUID.fromString(s);
+					ServerPlayerEntity p = victim.getServer().getPlayerManager().getPlayer(uuid);
+					if (p != null)
+						return Optional.of(p);
+				} catch (IllegalArgumentException ignored) {
+					// Not a UUID string
+				}
+			}
+		} catch (NoSuchMethodException | SecurityException ignored) {
+			// Method not present; ignore
+		} catch (Exception e) {
+			StormboundIslesMod.LOGGER.debug("getOwnerUuid reflection failed: {}", e.getMessage());
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * Attempts to resolve the killer player from the provided DamageSource.
+	 * Supports direct player attackers, projectiles with owners, and tameable
+	 * entities
+	 * exposing an owner UUID via common method names using reflection.
+	 */
+	private static Optional<ServerPlayerEntity> resolveKillerFromDamageSource(DamageSource src,
+			ServerPlayerEntity victim) {
+		if (src == null)
+			return Optional.empty();
+
+		Entity direct = src.getAttacker();
+		if (direct instanceof ServerPlayerEntity serverPlayer)
+			return Optional.of(serverPlayer);
+
+		if (direct == null)
+			return Optional.empty();
+
+		// Try owner via getOwner()
+		Optional<ServerPlayerEntity> maybe = getOwnerEntityViaGetOwner(direct);
+		if (maybe.isPresent())
+			return maybe;
+
+		// Try owner via getOwnerUuid()
+		return getOwnerEntityViaGetOwnerUuid(direct, victim);
 	}
 }

--- a/src/main/java/de/nofelix/stormboundisles/util/Constants.java
+++ b/src/main/java/de/nofelix/stormboundisles/util/Constants.java
@@ -54,7 +54,7 @@ public class Constants {
 	/** Name of the main scoreboard objective for team points */
 	public static final String SCOREBOARD_OBJECTIVE_NAME = "sbi_points";
 	/** Display title for the scoreboard */
-	public static final String SCOREBOARD_TITLE = "§b§lStormbound Isles";
+	public static final String SCOREBOARD_TITLE = "§6§lStormbound Isles";
 
 	// Command Constants
 	/**


### PR DESCRIPTION
This pull request introduces a configurable kill reward system for PvP deaths, refactors player death handling for clarity and extensibility, and improves configuration validation logic. The changes also expose team color and display name utilities for broader use and update the scoreboard title color.

**Kill reward and player death handling:**

* Added a configurable `killReward` value to the player config, with validation and logging, and exposed it via `ConfigManager.getPlayerKillReward()`. [[1]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R47) [[2]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R165-R166) [[3]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R447-R451) [[4]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9R343-R346) [[5]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9L214-R238)
* Refactored player death handling in `PlayerEventHandler`: now applies death penalty, awards kill rewards to killer's team (if from a different island), and revives/teleports the victim during the build phase. Includes robust killer resolution via direct entity, owner, or owner UUID using reflection. [[1]](diffhunk://#diff-d2d75f2ac58da4c40053acd5aae3ca2cca67ef6b1f10bd31998154851da86cebL46-R62) [[2]](diffhunk://#diff-d2d75f2ac58da4c40053acd5aae3ca2cca67ef6b1f10bd31998154851da86cebL215-R232) [[3]](diffhunk://#diff-d2d75f2ac58da4c40053acd5aae3ca2cca67ef6b1f10bd31998154851da86cebR242-R417)

**Configuration validation improvements:**

* Split config validation into separate methods per config section (game, player, buff, scoreboard, disaster) for maintainability and clarity. [[1]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9L182-R197) [[2]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9L201-R220) [[3]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9L227-R255) [[4]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9L240-R282) [[5]](diffhunk://#diff-6b4a9ec8e0453d253ba5390beca47524986db17fc03bf684b654f26f3884bba9L262-R297)

**Utility exposure and formatting:**

* Made `ScoreboardManager.getDisplayNameForTeam` and `getTeamColor` public for use outside the class; added a local copy of `getTeamColor` in `PlayerEventHandler` for message formatting. [[1]](diffhunk://#diff-30dfc6df9ce8605e10063140b32be40213511405bbf86664de033e246d556b3eL552-R552) [[2]](diffhunk://#diff-30dfc6df9ce8605e10063140b32be40213511405bbf86664de033e246d556b3eL562-R562) [[3]](diffhunk://#diff-d2d75f2ac58da4c40053acd5aae3ca2cca67ef6b1f10bd31998154851da86cebR41-R52)
* Updated the scoreboard title color to gold for improved visibility.